### PR TITLE
Add minimal skeleton for chan_dongle_ng module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+MODULE=chan_dongle_ng.so
+SRCS=src/chan_dongle_ng.c src/chan_dongle_ng_cli.c
+CFLAGS+=-fPIC -shared -Wall -I/usr/include/asterisk
+
+$(MODULE): $(SRCS)
+	$(CC) $(CFLAGS) -o $@ $^
+
+clean:
+	rm -f $(MODULE)
+
+.PHONY: clean

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # ast-dongle-ng
+
+This repository provides an experimental skeleton of the `chan_dongle_ng` Asterisk channel driver.  It is a starting point for a modern driver that replaces the legacy `chan_dongle` module.  The project is intentionally kept simple and uses a plain `Makefile` for building the shared object.
+
+Currently the code only implements a minimal channel driver that registers with Asterisk and exposes one CLI command:
+
+```
+asterisk -rx "dongle_ng reset <device>"
+```
+
+The command only logs a message; real reset logic needs to be implemented.
+
+To build the module run `make`.  The resulting `chan_dongle_ng.so` can be placed in Asterisk's modules directory.
+A working Asterisk development environment with headers is required to compile.

--- a/src/chan_dongle_ng.c
+++ b/src/chan_dongle_ng.c
@@ -1,0 +1,63 @@
+#include "chan_dongle_ng.h"
+
+static int load_module(void);
+static int unload_module(void);
+
+static struct ast_channel *dongle_request(const char *type, struct ast_format_cap *cap,
+                                          const struct ast_channel *requestor, const char *dest, int *cause);
+
+static struct ast_channel_tech dongle_ng_tech = {
+    .type = "Dongle_NG",
+    .description = "Minimal dongle_ng channel",
+    .requester = dongle_request,
+};
+
+static int load_module(void)
+{
+    int res;
+    res = ast_channel_register(&dongle_ng_tech);
+    if (res) {
+        ast_log(LOG_ERROR, DONGLE_NG_LOG_PREFIX "failed to register channel\n");
+        return AST_MODULE_LOAD_DECLINE;
+    }
+    if (dongle_ng_register_cli()) {
+        ast_channel_unregister(&dongle_ng_tech);
+        return AST_MODULE_LOAD_DECLINE;
+    }
+    ast_log(LOG_NOTICE, DONGLE_NG_LOG_PREFIX "module loaded\n");
+    return AST_MODULE_LOAD_SUCCESS;
+}
+
+static int unload_module(void)
+{
+    dongle_ng_unregister_cli();
+    ast_channel_unregister(&dongle_ng_tech);
+    ast_log(LOG_NOTICE, DONGLE_NG_LOG_PREFIX "module unloaded\n");
+    return 0;
+}
+
+static struct ast_module_info my_mod = {
+    .self = __FILE__,
+    .description = "dongle_ng channel",
+    .load = load_module,
+    .unload = unload_module,
+};
+
+AST_MODULE_INFO_STANDARD_EXTENDED(my_mod);
+
+static struct ast_channel *dongle_request(const char *type, struct ast_format_cap *cap,
+                                          const struct ast_channel *requestor, const char *dest, int *cause)
+{
+    struct ast_channel *chan;
+    chan = ast_channel_alloc(1, AST_STATE_DOWN, 0, 0, "dongle-ng", dest, NULL, NULL, requestor ? requestor->linkedid : NULL, 0, "Dongle/%s", dest);
+    if (!chan)
+        return NULL;
+
+    ast_format_cap_append(cap, ast_format_ulaw, 0);
+    ast_channel_set_writeformat(chan, ast_format_ulaw);
+    ast_channel_set_rawwriteformat(chan, ast_format_ulaw);
+    ast_channel_set_readformat(chan, ast_format_ulaw);
+    ast_channel_set_rawreadformat(chan, ast_format_ulaw);
+
+    return chan;
+}

--- a/src/chan_dongle_ng.h
+++ b/src/chan_dongle_ng.h
@@ -1,0 +1,25 @@
+#ifndef _CHAN_DONGLE_NG_H_
+#define _CHAN_DONGLE_NG_H_
+
+#include <asterisk.h>
+#include <asterisk/module.h>
+#include <asterisk/channel.h>
+#include <asterisk/logger.h>
+#include <asterisk/cli.h>
+#include <asterisk/config.h>
+#include <asterisk/lock.h>
+#include <asterisk/time.h>
+
+#define DONGLE_NG_LOG_PREFIX "[dongle_ng] "
+
+struct dongle_ng_device {
+    char imei[32];
+    char name[64];
+    char tty[256];
+    AST_RWLOCK_DEFINE(lock);
+};
+
+int dongle_ng_register_cli(void);
+void dongle_ng_unregister_cli(void);
+
+#endif /* _CHAN_DONGLE_NG_H_ */

--- a/src/chan_dongle_ng_cli.c
+++ b/src/chan_dongle_ng_cli.c
@@ -1,0 +1,36 @@
+#include "chan_dongle_ng.h"
+
+static char *handle_reset(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
+{
+    switch (cmd) {
+    case CLI_INIT:
+        e->command = "dongle_ng reset";
+        e->usage = "Usage: dongle_ng reset <device>\n       Reset a dongle device";
+        return NULL;
+    case CLI_GENERATE:
+        return NULL;
+    }
+
+    if (a->argc != 3)
+        return CLI_SHOWUSAGE;
+
+    ast_log(LOG_NOTICE, DONGLE_NG_LOG_PREFIX "reset device %s requested\n", a->argv[2]);
+    /* Here we'd trigger actual reset logic */
+    ast_cli(a->fd, "Dongle %s reset\n", a->argv[2]);
+
+    return CLI_SUCCESS;
+}
+
+static struct ast_cli_entry cli_cmd[] = {
+    AST_CLI_DEFINE(handle_reset, "Reset dongle"),
+};
+
+int dongle_ng_register_cli(void)
+{
+    return ast_cli_register_multiple(cli_cmd, ARRAY_LEN(cli_cmd));
+}
+
+void dongle_ng_unregister_cli(void)
+{
+    ast_cli_unregister_multiple(cli_cmd, ARRAY_LEN(cli_cmd));
+}


### PR DESCRIPTION
## Summary
- start a new `chan_dongle_ng` Asterisk channel driver
- provide a header, main module and CLI file
- implement a simple Makefile for building
- update README with build notes and CLI usage

## Testing
- `make` *(fails: `asterisk.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686acbfc8bb883329eb210050671bc5f